### PR TITLE
#32480 Fixed dependency versions, packaging.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,8 +12,8 @@
     
     <!-- Set the default versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
-		    <MetalamaVersion>0.5.80-preview</MetalamaVersion>
+        <PostSharpEngineeringVersion>1.0.114-preview</PostSharpEngineeringVersion>
+		<MetalamaVersion>0.5.80-preview</MetalamaVersion>
         <MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
     </PropertyGroup>
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,9 +12,9 @@
     
     <!-- Set the default versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.112-preview</PostSharpEngineeringVersion>
-		<MetalamaVersion>branch:master</MetalamaVersion>
-        <MetalamaVersion Condition="$(VcsBranch.StartsWith('master'))">0.5.79-preview</MetalamaVersion>
+        <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
+		<MetalamaVersion>0.5.79-preview</MetalamaVersion>
+        <MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
     </PropertyGroup>
 
     <!-- Override versions (both this product and dependencies) for the local build -->

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "minor"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.113-preview"
+    "PostSharp.Engineering.Sdk": "1.0.114-preview"
   }
 }

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "minor"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.112-preview"
+    "PostSharp.Engineering.Sdk": "1.0.113-preview"
   }
 }

--- a/src/Metalama.Extensions.Metrics/Metalama.Extensions.Metrics.csproj
+++ b/src/Metalama.Extensions.Metrics/Metalama.Extensions.Metrics.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageId>Metalama.Extensions.Metrics.Redist</PackageId>
+        <PackageDescription>Redistributable components for package 'Metalama.Extensions.Metrics'. This package should only be installed as a dependency. (This is not the package you are looking for if you want to use Metalama.Extensions.Metrics). </PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Changes:
* Changed dependencies versions to build with `dotnet build` correctly.
* Updated Engineering for Merge Publisher change.

